### PR TITLE
[FEAT] Added commit message templating

### DIFF
--- a/.rona.toml
+++ b/.rona.toml
@@ -5,3 +5,7 @@ commit_types = [
     "fix",
     "docs",
 ]
+
+# Template for interactive commit message generation
+# Available variables: {commit_number}, {commit_type}, {branch_name}, {message}, {date}, {time}, {author}, {email}
+template = "[{commit_number}] ({commit_type} on {branch_name}) {message}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,16 +169,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link 0.2.0",
+]
 
 [[package]]
 name = "clap"
@@ -299,6 +338,12 @@ checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -464,6 +509,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+
+[[package]]
 name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +623,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +684,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "json5"
@@ -726,6 +811,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -943,9 +1037,10 @@ dependencies = [
 
 [[package]]
 name = "rona"
-version = "2.8.4"
+version = "2.8.5"
 dependencies = [
  "assert_cmd",
+ "chrono",
  "clap",
  "clap_complete",
  "config",
@@ -984,6 +1079,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.61.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -1078,6 +1179,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -1338,6 +1445,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1526,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.0",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1571,24 @@ name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "Apache-2.0 OR MIT"
 name = "rona"
 readme = "README.md"
 repository = "https://github.com/tomplanche/rona"
-version = "2.8.4"
+version = "2.8.5"
 
 [[bin]]
 doc = true
@@ -35,6 +35,7 @@ config = "0.14.1"
 serde = { version = "1.0", features = ["derive"] }
 dirs = "5.0.1"
 toml = "0.8"
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.17"

--- a/README.md
+++ b/README.md
@@ -55,9 +55,47 @@ commit_types = [
     "test",    # Adding or updating tests
     "chore"    # Maintenance tasks
 ]
+
+# Template for interactive commit message generation
+# Available variables: {commit_number}, {commit_type}, {branch_name}, {message}, {date}, {time}, {author}, {email}
+template = "[{commit_number}] ({commit_type} on {branch_name}) {message}"
 ```
 
 **Note**: When no configuration exists, Rona falls back to: `["chore", "feat", "fix", "test"]`
+
+### Template Configuration
+
+Rona supports customizable templates for interactive commit message generation. You can define how your commit messages are formatted using variables:
+
+**Available Template Variables:**
+- `{commit_number}` - The commit number (incremental)
+- `{commit_type}` - The selected commit type (feat, fix, etc.)
+- `{branch_name}` - The current branch name
+- `{message}` - Your input message
+- `{date}` - Current date (YYYY-MM-DD)
+- `{time}` - Current time (HH:MM:SS)
+- `{author}` - Git author name
+- `{email}` - Git author email
+
+**Template Examples:**
+```toml
+# Default template
+template = "[{commit_number}] ({commit_type} on {branch_name}) {message}"
+
+# Simple format without commit number
+template = "({commit_type}) {message}"
+
+# Include date and time
+template = "[{date} {time}] {commit_type}: {message}"
+
+# Include author information
+template = "{commit_type}: {message} (by {author})"
+
+# Custom format
+template = "🚀 {commit_type} on {branch_name}: {message}"
+```
+
+**Note**: If no template is specified, Rona uses the default format: `[{commit_number}] ({commit_type} on {branch_name}) {message}`
 
 ### Working with Configuration
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,10 @@ pub struct ProjectConfig {
 
     /// Custom commit types for this project
     pub commit_types: Option<Vec<String>>,
+
+    /// Template for interactive commit message generation
+    /// Available variables: {`commit_number`}, {`commit_type`}, {`branch_name`}, {`message`}, {`date`}, {`time`}, {`author`}, {`email`}
+    pub template: Option<String>,
 }
 
 impl Default for ProjectConfig {
@@ -56,6 +60,9 @@ impl Default for ProjectConfig {
                     .iter()
                     .map(std::string::ToString::to_string)
                     .collect(),
+            ),
+            template: Some(
+                "[{commit_number}] ({commit_type} on {branch_name}) {message}".to_string(),
             ),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ pub mod config;
 pub mod errors;
 pub mod git;
 pub mod performance;
+pub mod template;
 pub mod utils;
 
 use cli::run;

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,0 +1,332 @@
+//! Template Processing Module for Rona
+//!
+//! This module handles template parsing and variable substitution for commit messages.
+//! It provides a flexible templating system that allows users to customize how their
+//! commit messages are formatted using variables.
+
+use crate::errors::{Result, RonaError};
+use chrono::Local;
+use regex::Regex;
+use std::collections::HashMap;
+use std::process::Command;
+
+/// Template variables that can be used in commit message templates
+#[derive(Debug, Clone)]
+pub struct TemplateVariables {
+    pub commit_number: Option<u32>,
+    pub commit_type: String,
+    pub branch_name: String,
+    pub message: String,
+    pub date: String,
+    pub time: String,
+    pub author: String,
+    pub email: String,
+}
+
+impl TemplateVariables {
+    /// Creates a new `TemplateVariables` instance with current date/time and git info
+    ///
+    /// # Errors
+    /// * If git author information cannot be retrieved
+    pub fn new(
+        commit_number: Option<u32>,
+        commit_type: String,
+        branch_name: String,
+        message: String,
+    ) -> Result<Self> {
+        let now = Local::now();
+        let (author, email) = get_git_author_info()?;
+
+        Ok(Self {
+            commit_number,
+            commit_type,
+            branch_name,
+            message,
+            date: now.format("%Y-%m-%d").to_string(),
+            time: now.format("%H:%M:%S").to_string(),
+            author,
+            email,
+        })
+    }
+
+    /// Converts the variables to a `HashMap` for template substitution
+    #[must_use]
+    pub fn to_map(&self) -> HashMap<String, String> {
+        let mut map = HashMap::new();
+
+        map.insert("commit_type".to_string(), self.commit_type.clone());
+        map.insert("branch_name".to_string(), self.branch_name.clone());
+        map.insert("message".to_string(), self.message.clone());
+        map.insert("date".to_string(), self.date.clone());
+        map.insert("time".to_string(), self.time.clone());
+        map.insert("author".to_string(), self.author.clone());
+        map.insert("email".to_string(), self.email.clone());
+
+        if let Some(commit_number) = self.commit_number {
+            map.insert("commit_number".to_string(), commit_number.to_string());
+        } else {
+            map.insert("commit_number".to_string(), String::new());
+        }
+
+        map
+    }
+}
+
+/// Processes a template string by substituting variables with their values
+///
+/// # Arguments
+/// * `template` - The template string containing variables in {`variable_name`} format
+/// * `variables` - The variables to substitute
+///
+/// # Returns
+/// * `Result<String>` - The processed template with variables substituted
+///
+/// # Errors
+/// * If the template contains invalid variable syntax
+/// * If required variables are missing
+pub fn process_template(template: &str, variables: &TemplateVariables) -> Result<String> {
+    let variable_map = variables.to_map();
+    let mut result = template.to_string();
+
+    // Find all variables in the template
+    let regex = Regex::new(r"\{([^}]+)\}").map_err(|e| {
+        RonaError::Io(std::io::Error::other(format!(
+            "Invalid template regex: {e}"
+        )))
+    })?;
+
+    // Replace each variable with its value
+    for capture in regex.captures_iter(template) {
+        if let Some(variable_name) = capture.get(1) {
+            let var_name = variable_name.as_str();
+            let empty_string = String::new();
+            let value = variable_map.get(var_name).unwrap_or(&empty_string);
+            result = result.replace(&capture[0], value);
+        }
+    }
+
+    Ok(result)
+}
+
+/// Validates a template string to ensure it contains only valid variables
+///
+/// # Arguments
+/// * `template` - The template string to validate
+///
+/// # Returns
+/// * `Result<()>` - Ok if valid, Err if invalid variables found
+///
+/// # Errors
+/// * If the template contains unknown variables
+pub fn validate_template(template: &str) -> Result<()> {
+    let valid_variables = [
+        "commit_number",
+        "commit_type",
+        "branch_name",
+        "message",
+        "date",
+        "time",
+        "author",
+        "email",
+    ];
+
+    let regex = Regex::new(r"\{([^}]+)\}").map_err(|e| {
+        RonaError::Io(std::io::Error::other(format!(
+            "Invalid template regex: {e}"
+        )))
+    })?;
+
+    for capture in regex.captures_iter(template) {
+        if let Some(variable_name) = capture.get(1) {
+            let var_name = variable_name.as_str();
+            if !valid_variables.contains(&var_name) {
+                return Err(RonaError::Io(std::io::Error::other(format!(
+                    "Unknown template variable: {{{var_name}}}. Valid variables are: {}",
+                    valid_variables.join(", ")
+                ))));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Gets the current git author name and email
+fn get_git_author_info() -> Result<(String, String)> {
+    let name_output = Command::new("git")
+        .args(["config", "user.name"])
+        .output()
+        .map_err(|e| {
+            RonaError::Io(std::io::Error::other(format!(
+                "Failed to get git user name: {e}"
+            )))
+        })?;
+
+    let email_output = Command::new("git")
+        .args(["config", "user.email"])
+        .output()
+        .map_err(|e| {
+            RonaError::Io(std::io::Error::other(format!(
+                "Failed to get git user email: {e}"
+            )))
+        })?;
+
+    let name = String::from_utf8_lossy(&name_output.stdout)
+        .trim()
+        .to_string();
+    let email = String::from_utf8_lossy(&email_output.stdout)
+        .trim()
+        .to_string();
+
+    Ok((name, email))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_template_processing() {
+        let template = "[{commit_number}] ({commit_type} on {branch_name}) {message}";
+        let variables = TemplateVariables {
+            commit_number: Some(42),
+            commit_type: "feat".to_string(),
+            branch_name: "feature/new-feature".to_string(),
+            message: "Add new functionality".to_string(),
+            date: "2024-01-15".to_string(),
+            time: "14:30:00".to_string(),
+            author: "John Doe".to_string(),
+            email: "john@example.com".to_string(),
+        };
+
+        let result = process_template(template, &variables).unwrap();
+        assert_eq!(
+            result,
+            "[42] (feat on feature/new-feature) Add new functionality"
+        );
+    }
+
+    #[test]
+    fn test_template_without_commit_number() {
+        let template = "({commit_type} on {branch_name}) {message}";
+        let variables = TemplateVariables {
+            commit_number: None,
+            commit_type: "fix".to_string(),
+            branch_name: "main".to_string(),
+            message: "Fix bug".to_string(),
+            date: "2024-01-15".to_string(),
+            time: "14:30:00".to_string(),
+            author: "John Doe".to_string(),
+            email: "john@example.com".to_string(),
+        };
+
+        let result = process_template(template, &variables).unwrap();
+        assert_eq!(result, "(fix on main) Fix bug");
+    }
+
+    #[test]
+    fn test_template_validation_valid() {
+        let template = "[{commit_number}] ({commit_type} on {branch_name}) {message}";
+        assert!(validate_template(template).is_ok());
+    }
+
+    #[test]
+    fn test_template_validation_invalid() {
+        let template = "[{commit_number}] ({invalid_var} on {branch_name}) {message}";
+        assert!(validate_template(template).is_err());
+    }
+
+    #[test]
+    fn test_template_variables_to_map() {
+        let variables = TemplateVariables {
+            commit_number: Some(42),
+            commit_type: "feat".to_string(),
+            branch_name: "feature/test".to_string(),
+            message: "Test message".to_string(),
+            date: "2024-01-15".to_string(),
+            time: "14:30:00".to_string(),
+            author: "Test Author".to_string(),
+            email: "test@example.com".to_string(),
+        };
+
+        let map = variables.to_map();
+        assert_eq!(map.get("commit_number").unwrap(), "42");
+        assert_eq!(map.get("commit_type").unwrap(), "feat");
+        assert_eq!(map.get("branch_name").unwrap(), "feature/test");
+        assert_eq!(map.get("message").unwrap(), "Test message");
+        assert_eq!(map.get("date").unwrap(), "2024-01-15");
+        assert_eq!(map.get("time").unwrap(), "14:30:00");
+        assert_eq!(map.get("author").unwrap(), "Test Author");
+        assert_eq!(map.get("email").unwrap(), "test@example.com");
+    }
+
+    #[test]
+    fn test_template_with_all_variables() {
+        let template = "{commit_type}: {message} by {author} <{email}> on {branch_name} at {date} {time} (#{commit_number})";
+        let variables = TemplateVariables {
+            commit_number: Some(123),
+            commit_type: "fix".to_string(),
+            branch_name: "hotfix/critical-bug".to_string(),
+            message: "Fix critical authentication bug".to_string(),
+            date: "2024-01-15".to_string(),
+            time: "14:30:00".to_string(),
+            author: "Jane Doe".to_string(),
+            email: "jane@company.com".to_string(),
+        };
+
+        let result = process_template(template, &variables).unwrap();
+        assert_eq!(
+            result,
+            "fix: Fix critical authentication bug by Jane Doe <jane@company.com> on hotfix/critical-bug at 2024-01-15 14:30:00 (#123)"
+        );
+    }
+
+    #[test]
+    fn test_template_with_emoji() {
+        let template = "🚀 {commit_type}: {message}";
+        let variables = TemplateVariables {
+            commit_number: None,
+            commit_type: "feat".to_string(),
+            branch_name: "feature/new-feature".to_string(),
+            message: "Add new feature".to_string(),
+            date: "2024-01-15".to_string(),
+            time: "14:30:00".to_string(),
+            author: "John Doe".to_string(),
+            email: "john@example.com".to_string(),
+        };
+
+        let result = process_template(template, &variables).unwrap();
+        assert_eq!(result, "🚀 feat: Add new feature");
+    }
+
+    #[test]
+    fn test_template_without_commit_number_variable() {
+        let template = "({commit_type} on {branch_name}) {message}";
+        let variables = TemplateVariables {
+            commit_number: None,
+            commit_type: "docs".to_string(),
+            branch_name: "main".to_string(),
+            message: "Update documentation".to_string(),
+            date: "2024-01-15".to_string(),
+            time: "14:30:00".to_string(),
+            author: "John Doe".to_string(),
+            email: "john@example.com".to_string(),
+        };
+
+        let result = process_template(template, &variables).unwrap();
+        assert_eq!(result, "(docs on main) Update documentation");
+    }
+
+    #[test]
+    fn test_template_validation_with_unknown_variable() {
+        let template = "[{commit_number}] ({unknown_var} on {branch_name}) {message}";
+        let result = validate_template(template);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Unknown template variable")
+        );
+    }
+}


### PR DESCRIPTION
- `.rona.toml`:
```
# Template for interactive commit message generation
# Available variables: {commit_number}, {commit_type}, {branch_name}, {message}, {date}, {time}, {author}, {email}
template = "[{commit_number}] ({commit_type} on {branch_name}) {message}"
```