### PR TITLE
[FIX] Tests do not interfere with git config + `commit_message.md` now creates the file in project's root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "rona"
-version = "2.10.3"
+version = "2.10.4"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "Apache-2.0 OR MIT"
 name = "rona"
 readme = "README.md"
 repository = "https://github.com/tomplanche/rona"
-version = "2.10.3"
+version = "2.10.4"
 
 [[bin]]
 doc = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,7 +38,7 @@ use crate::{
     git::{
         COMMIT_MESSAGE_FILE_PATH, COMMIT_TYPES, create_needed_files, format_branch_name,
         generate_commit_message, get_current_branch, get_current_commit_nb, get_status_files,
-        git_add_with_exclude_patterns, git_commit, git_push,
+        get_top_level_path, git_add_with_exclude_patterns, git_commit, git_push,
     },
     template::{TemplateVariables, process_template, validate_template},
 };
@@ -334,6 +334,9 @@ fn handle_interactive_mode(
     println!("📝 Interactive mode: Enter your commit message.");
     println!("💡 Tip: Keep it concise and descriptive.");
 
+    let project_root = get_top_level_path()?;
+    let commit_file_path = project_root.join(COMMIT_MESSAGE_FILE_PATH);
+
     let message: String = Text::new("Message").prompt().unwrap();
 
     if message.trim().is_empty() {
@@ -376,7 +379,7 @@ fn handle_interactive_mode(
                 message.trim()
             )
         };
-        fs::write(COMMIT_MESSAGE_FILE_PATH, &formatted_message)?;
+        fs::write(&commit_file_path, &formatted_message)?;
         println!("\n✅ Commit message created!");
         println!("📄 Message: {formatted_message}");
         return Ok(());
@@ -394,7 +397,7 @@ fn handle_interactive_mode(
     let formatted_message = process_template(template, &variables)?;
 
     // Write the formatted message to commit_message.md
-    fs::write(COMMIT_MESSAGE_FILE_PATH, &formatted_message)?;
+    fs::write(&commit_file_path, &formatted_message)?;
 
     println!("\n✅ Commit message created!");
     println!("📄 Message: {formatted_message}");
@@ -404,9 +407,11 @@ fn handle_interactive_mode(
 /// Handle editor mode for generate command
 fn handle_editor_mode(config: &Config) -> Result<()> {
     let editor = config.get_editor()?;
+    let project_root = get_top_level_path()?;
+    let commit_file_path = project_root.join(COMMIT_MESSAGE_FILE_PATH);
 
     Command::new(editor)
-        .arg(COMMIT_MESSAGE_FILE_PATH)
+        .arg(&commit_file_path)
         .spawn()
         .expect("Failed to spawn editor")
         .wait()

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,8 @@ use std::{env, io::Write, path::PathBuf};
 
 use crate::{
     errors::{ConfigError, GitError, Result},
-    utils::{find_project_root, print_error},
+    git::get_top_level_path,
+    utils::print_error,
 };
 
 // Define your default commit types
@@ -254,9 +255,7 @@ impl Config {
             .map_err(|_| ConfigError::InvalidConfig)?;
 
         let config_path = match selection {
-            "Project (./.rona.toml)" => find_project_root()
-                .map(|root| root.join(".rona.toml"))
-                .map_err(|_| ConfigError::ConfigNotFound)?,
+            "Project (./.rona.toml)" => get_top_level_path().map(|root| root.join(".rona.toml"))?,
             "Global (~/.config/rona.toml)" => {
                 let home = dirs::home_dir().ok_or(ConfigError::ConfigNotFound)?;
                 home.join(".config/rona.toml")

--- a/src/git/files.rs
+++ b/src/git/files.rs
@@ -12,8 +12,8 @@ use std::{
 
 use crate::{
     errors::Result,
-    git::{COMMIT_MESSAGE_FILE_PATH, find_git_root},
-    utils::{find_project_root, print_error},
+    git::{COMMIT_MESSAGE_FILE_PATH, find_git_root, get_top_level_path},
+    utils::print_error,
 };
 
 const COMMITIGNORE_FILE_PATH: &str = ".commitignore";
@@ -90,13 +90,13 @@ pub fn add_to_git_exclude(paths: &[&str]) -> Result<()> {
     Ok(())
 }
 
-/// Creates the necessary files in the project root.
+/// Creates the necessary files in the git repository root.
 ///
 /// # Errors
 /// * If the files cannot be created.
 /// * If the git add command fails.
 pub fn create_needed_files() -> Result<()> {
-    let project_root = find_project_root()?;
+    let project_root = get_top_level_path()?;
 
     let commit_file_path = Path::new(&project_root).join(COMMIT_MESSAGE_FILE_PATH);
     let commitignore_file_path = Path::new(&project_root).join(COMMITIGNORE_FILE_PATH);

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -33,7 +33,7 @@ pub use commit::{
 };
 pub use files::create_needed_files;
 pub use remote::git_push;
-pub use repository::find_git_root;
+pub use repository::{find_git_root, get_top_level_path};
 pub use staging::git_add_with_exclude_patterns;
 pub use status::get_status_files;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,10 +26,9 @@
 //! for proper error handling throughout the application.
 
 use std::{
-    env,
     fmt::Display,
     io::{Error as IoError, ErrorKind},
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 /// Trait for message types.
@@ -161,38 +160,6 @@ pub fn check_for_file_in_folder(file_path: &Path, folder_path: &Path) -> Result<
 
     // Check if file_path starts with folder_path
     Ok(file_parent.starts_with(folder_path))
-}
-
-/// Finds the root directory of a project by searching for a `.git` directory.
-///
-/// # Errors
-/// * If getting the current directory fails
-/// * If the project root is not found
-///
-/// Returns:
-/// * `Ok(PathBuf)` - The path to the project root directory
-/// * `Err(std::io::Error)` - If there's an error processing the paths
-pub fn find_project_root() -> Result<PathBuf, IoError> {
-    let mut current_dir = env::current_dir()?;
-
-    while current_dir.parent().is_some() {
-        let git_dir = current_dir.join(".git");
-        if git_dir.exists() {
-            return Ok(current_dir);
-        }
-
-        let parent_dir = current_dir.parent().ok_or(IoError::new(
-            ErrorKind::InvalidInput,
-            "Invalid file path: cannot get parent directory",
-        ))?;
-
-        current_dir = parent_dir.to_path_buf();
-    }
-
-    Err(IoError::new(
-        ErrorKind::InvalidInput,
-        "Invalid file path: cannot get parent directory",
-    ))
 }
 
 #[cfg(test)]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -112,24 +112,30 @@ fn test_commit_command() {
     git_init.current_dir(temp_path).arg("init");
     git_init.assert().success();
 
-    // Configure git user
+    // Configure git user (using --local to only affect this test repository)
     let mut git_config = Command::new("git");
     git_config
         .current_dir(temp_path)
-        .args(["config", "user.name", "Test User"]);
+        .args(["config", "--local", "user.name", "Test User"]);
     git_config.assert().success();
 
     let mut git_config_email = Command::new("git");
-    git_config_email
-        .current_dir(temp_path)
-        .args(["config", "user.email", "test@example.com"]);
+    git_config_email.current_dir(temp_path).args([
+        "config",
+        "--local",
+        "user.email",
+        "test@example.com",
+    ]);
     git_config_email.assert().success();
 
-    // Ensure GPG signing does not interfere with the test
+    // Ensure GPG signing does not interfere with the test (using --local)
     let mut git_disable_gpgsign = Command::new("git");
-    git_disable_gpgsign
-        .current_dir(temp_path)
-        .args(["config", "commit.gpgsign", "false"]);
+    git_disable_gpgsign.current_dir(temp_path).args([
+        "config",
+        "--local",
+        "commit.gpgsign",
+        "false",
+    ]);
     git_disable_gpgsign.assert().success();
 
     // Create and stage a test file


### PR DESCRIPTION
Tests were using `git config user.email "test@example.com"` and `git config user.name "Test User"` which were messing with machine git config, now they use `--local`.

Sometimes, if not in the project's root, the `commit_message.md` file was created where the CLI was called.