### PR TITLE
[FIX] Fix intel build + use PAT for triggering tag push trigger action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,7 +79,7 @@ jobs:
   build-macos-intel:
     needs: extract-version
     name: Build macOS Intel Binary
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/tag-on-version-bump.yaml
+++ b/.github/workflows/tag-on-version-bump.yaml
@@ -18,6 +18,7 @@ jobs:
               with:
                   fetch-depth: 0
                   fetch-tags: true
+                  token: ${{ secrets.PAT_TOKEN }}
 
             - name: Determine previous and current versions
               id: versions


### PR DESCRIPTION
 build-macos-intel (failed):
  - Runner: macos-latest = Apple Silicon (ARM64)
  - Target: x86_64-apple-darwin (Intel x86_64)
  - This is cross-compilation - building Intel code on ARM hardware
  
  Now, uses `macos-13`.