### PR TITLE
[FEAT] configurable built-in prompts, rename field_order, preserve branch name case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -172,9 +172,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -225,9 +225,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -241,9 +241,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -494,7 +494,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
 ]
 
@@ -732,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -802,7 +802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -826,7 +826,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
@@ -851,13 +851,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -892,9 +891,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -916,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "matchers"
@@ -931,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -1051,7 +1050,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -1063,7 +1062,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -1074,7 +1073,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -1093,7 +1092,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1104,7 +1103,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1227,7 +1226,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1319,7 +1318,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1335,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1358,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ron"
@@ -1369,14 +1368,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "serde",
  "serde_derive",
 ]
 
 [[package]]
 name = "rona"
-version = "2.23.1"
+version = "2.23.2"
 dependencies = [
  "arboard",
  "assert_cmd",
@@ -1415,7 +1414,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1472,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1514,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -1563,9 +1562,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "strsim"
@@ -1779,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -1797,9 +1796,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -1860,9 +1859,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -1878,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1891,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1901,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1914,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -1949,7 +1948,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2274,7 +2273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
@@ -2334,18 +2333,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "Apache-2.0 OR MIT"
 name = "rona"
 readme = "README.md"
 repository = "https://github.com/rona-rs/rona"
-version = "2.23.1"
+version = "2.23.2"
 
 [[bin]]
 doc = true
@@ -25,10 +25,10 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
-clap_complete = "4.6.3"
+clap_complete = "4.6.5"
 inquire = { version = "0.7" }
 glob = "0.3.3"
-regex = "1.12.3"
+regex = "1.12.4"
 thiserror = "2.0.18"
 config = "0.14.1"
 serde = { version = "1.0", features = ["derive"] }
@@ -42,7 +42,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 colored = "3.1.1"
 
 [dev-dependencies]
-assert_cmd = "2.2.1"
+assert_cmd = "2.2.2"
 mockall = "0.13.1"
 tempfile = "3.27.0"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,7 +37,10 @@ use std::{collections::HashMap, fs::read_to_string, io, process::Command};
 use crate::{
     config::{Config, find_config_sources},
     errors::{Result, RonaError},
-    extra_fields::{ExtraField, MessagePrefetchConfig, prompt_extra_field, run_message_prefetch},
+    extra_fields::{
+        BuiltInFieldConfig, ExtraField, MessagePrefetchConfig, prompt_extra_field,
+        run_message_prefetch,
+    },
     git::{
         COMMIT_MESSAGE_FILE_PATH, COMMIT_TYPES, add_to_git_exclude, create_needed_files,
         format_branch_name, generate_commit_message, get_current_branch, get_current_commit_nb,
@@ -336,12 +339,18 @@ fn prompt_branch_fields(
     extra_fields: &[ExtraField],
     field_order: &[String],
     needs_description: bool,
+    description_config: Option<&BuiltInFieldConfig>,
 ) -> Result<(String, HashMap<String, String>)> {
+    use inquire::validator::Validation;
+
     const DESCRIPTION_KEY: &str = "description";
+
+    let description_disabled = description_config.is_some_and(|c| c.disabled);
+    let effective_needs_description = needs_description && !description_disabled;
 
     let ordered: Vec<String> = if field_order.is_empty() {
         let mut v: Vec<String> = extra_fields.iter().map(|f| f.name.clone()).collect();
-        if needs_description {
+        if effective_needs_description {
             v.push(DESCRIPTION_KEY.to_string());
         }
         v
@@ -352,7 +361,7 @@ fn prompt_branch_fields(
                 v.push(f.name.clone());
             }
         }
-        if needs_description && !v.iter().any(|s| s == DESCRIPTION_KEY) {
+        if effective_needs_description && !v.iter().any(|s| s == DESCRIPTION_KEY) {
             v.push(DESCRIPTION_KEY.to_string());
         }
         v
@@ -363,11 +372,34 @@ fn prompt_branch_fields(
 
     for name in &ordered {
         if name == DESCRIPTION_KEY {
-            description = Some(
-                Text::new("Branch description")
+            let prompt_text = description_config
+                .and_then(|c| c.prompt.as_deref())
+                .unwrap_or("Branch description");
+            let validator_pattern = description_config.and_then(|c| c.validation.as_deref());
+            let value = if let Some(pattern) = validator_pattern {
+                let re = regex::Regex::new(pattern).map_err(|e| {
+                    RonaError::InvalidInput(format!(
+                        "Invalid validation regex for branch description: {e}"
+                    ))
+                })?;
+                let pattern_owned = pattern.to_string();
+                Text::new(prompt_text)
+                    .with_validator(move |input: &str| {
+                        if !re.is_match(input) {
+                            return Ok(Validation::Invalid(
+                                format!("Must match pattern: {pattern_owned}").into(),
+                            ));
+                        }
+                        Ok(Validation::Valid)
+                    })
                     .prompt()
-                    .map_err(|_| RonaError::UserCancelled)?,
-            );
+                    .map_err(|_| RonaError::UserCancelled)?
+            } else {
+                Text::new(prompt_text)
+                    .prompt()
+                    .map_err(|_| RonaError::UserCancelled)?
+            };
+            description = Some(value);
         } else if let Some(field) = extra_fields.iter().find(|f| f.name == *name)
             && let Some(value) = prompt_extra_field(field)?
         {
@@ -425,10 +457,24 @@ fn handle_branch(no_switch: bool, config: &Config) -> Result<()> {
     let needs_description =
         template.contains("{description}") || template.contains("{?description}");
 
+    // Build the effective field list for branch prompts: start with branch_extra_fields, then
+    // pull in any commit_extra_fields whose names are referenced in the template but not already
+    // covered by a branch_extra_field with the same name.
+    let mut effective_branch_fields: Vec<ExtraField> =
+        config.project_config.branch_extra_fields.clone();
+    for commit_field in &config.project_config.commit_extra_fields {
+        let in_template = template.contains(&format!("{{{}}}", commit_field.name))
+            || template.contains(&format!("{{?{}}}", commit_field.name));
+        let already_present = effective_branch_fields
+            .iter()
+            .any(|f| f.name == commit_field.name);
+        if in_template && !already_present {
+            effective_branch_fields.push(commit_field.clone());
+        }
+    }
+
     // Validate template and warn about unreferenced fields before prompting the user.
-    let extra_names: Vec<&str> = config
-        .project_config
-        .branch_extra_fields
+    let extra_names: Vec<&str> = effective_branch_fields
         .iter()
         .map(|f| f.name.as_str())
         .collect();
@@ -459,9 +505,10 @@ fn handle_branch(no_switch: bool, config: &Config) -> Result<()> {
     };
 
     let (description, extra_values) = prompt_branch_fields(
-        &config.project_config.branch_extra_fields,
+        &effective_branch_fields,
         &config.project_config.branch_field_order,
         needs_description,
+        config.project_config.branch_description.as_ref(),
     )?;
 
     if needs_description && description.trim().is_empty() {
@@ -631,12 +678,19 @@ fn prompt_interactive_fields(
     extra_fields: &[ExtraField],
     field_order: &[String],
     message_prefetch: Option<&MessagePrefetchConfig>,
+    message_config: Option<&BuiltInFieldConfig>,
 ) -> Result<(String, HashMap<String, String>)> {
+    use inquire::validator::Validation;
+
     const MESSAGE_KEY: &str = "message";
+
+    let message_disabled = message_config.is_some_and(|c| c.disabled);
 
     let ordered: Vec<String> = if field_order.is_empty() {
         let mut v: Vec<String> = extra_fields.iter().map(|f| f.name.clone()).collect();
-        v.push(MESSAGE_KEY.to_string());
+        if !message_disabled {
+            v.push(MESSAGE_KEY.to_string());
+        }
         v
     } else {
         let mut v: Vec<String> = field_order.to_vec();
@@ -646,8 +700,8 @@ fn prompt_interactive_fields(
                 v.push(f.name.clone());
             }
         }
-        // Guarantee message is always prompted
-        if !v.iter().any(|s| s == MESSAGE_KEY) {
+        // Guarantee message is always prompted unless disabled
+        if !message_disabled && !v.iter().any(|s| s == MESSAGE_KEY) {
             v.push(MESSAGE_KEY.to_string());
         }
         v
@@ -658,15 +712,42 @@ fn prompt_interactive_fields(
 
     for name in &ordered {
         if name == MESSAGE_KEY {
+            let prompt_text = message_config
+                .and_then(|c| c.prompt.as_deref())
+                .unwrap_or("Message");
             let default = message_prefetch
                 .map(run_message_prefetch)
                 .transpose()?
                 .flatten();
-            let mut prompt = Text::new("Message");
-            if let Some(ref d) = default {
-                prompt = prompt.with_default(d.as_str());
-            }
-            message = Some(prompt.prompt().map_err(|_| RonaError::UserCancelled)?);
+            let validator_pattern = message_config.and_then(|c| c.validation.as_deref());
+            let value = if let Some(pattern) = validator_pattern {
+                let re = regex::Regex::new(pattern).map_err(|e| {
+                    RonaError::InvalidInput(format!("Invalid validation regex for message: {e}"))
+                })?;
+                let pattern_owned = pattern.to_string();
+                let mut text_prompt = Text::new(prompt_text);
+                if let Some(ref d) = default {
+                    text_prompt = text_prompt.with_default(d.as_str());
+                }
+                text_prompt
+                    .with_validator(move |input: &str| {
+                        if !re.is_match(input) {
+                            return Ok(Validation::Invalid(
+                                format!("Must match pattern: {pattern_owned}").into(),
+                            ));
+                        }
+                        Ok(Validation::Valid)
+                    })
+                    .prompt()
+                    .map_err(|_| RonaError::UserCancelled)?
+            } else {
+                let mut text_prompt = Text::new(prompt_text);
+                if let Some(ref d) = default {
+                    text_prompt = text_prompt.with_default(d.as_str());
+                }
+                text_prompt.prompt().map_err(|_| RonaError::UserCancelled)?
+            };
+            message = Some(value);
         } else if let Some(field) = extra_fields.iter().find(|f| f.name == *name)
             && let Some(value) = prompt_extra_field(field)?
         {
@@ -717,8 +798,9 @@ fn handle_generate(interactive: bool, no_commit_number: bool, config: &Config) -
         // In interactive mode, prompt all fields (including message) in configured order
         let (message, extra_values) = prompt_interactive_fields(
             &config.project_config.commit_extra_fields,
-            &config.project_config.field_order,
+            &config.project_config.commit_fields_order,
             config.project_config.message_prefetch.as_ref(),
+            config.project_config.commit_message.as_ref(),
         )?;
         handle_interactive_mode(
             commit_type,
@@ -1076,6 +1158,106 @@ fn handle_which_config(path: Option<&str>, show_effective: bool) -> Result<()> {
 
 /// Handle the Config command which creates or manages configuration files.
 ///
+/// Generates a commented TOML config file content with all supported options documented.
+fn generate_commented_config() -> String {
+    let default_commit_types = r#"["feat", "fix", "perf", "revert", "docs", "quality", "style", "chore", "refactor", "test", "build", "ci"]"#;
+    format!(
+        r#"# Editor used to open commit_message.md in non-interactive mode.
+editor = "nano"
+
+# Commit types shown in the selector.
+commit_types = {default_commit_types}
+
+##########
+# COMMIT #
+##########
+
+# Template applied to the final commit message.
+# Built-in variables:
+#   {{commit_number}}  - sequential commit count on the current branch
+#   {{commit_type}}    - the type chosen in the selector
+#   {{branch_name}}    - current branch (prefix stripped, e.g. feat/x -> x)
+#   {{message}}        - the message entered by the user
+#   {{date}}           - YYYY-MM-DD
+#   {{time}}           - HH:MM:SS
+#   {{author}}         - git user.name
+#   {{email}}          - git user.email
+# Conditional blocks: {{?var}}...{{/var}} renders only when var has a value.
+# Extra variables: add with [[commit_extra_fields]].
+commit_template = "{{?commit_number}}[{{commit_number}}] {{/commit_number}}({{commit_type}} on {{branch_name}}) {{message}}"
+
+# Order of prompts in interactive mode (-i).
+# Use the reserved name "message" to position the built-in message prompt.
+# Fields not listed are appended after all listed items.
+# commit_fields_order = ["scope", "message", "ticket"]
+
+# Overrides for the built-in message prompt (uncomment to customise or disable).
+# [commit_message]
+# prompt = "Commit message"
+# validation = ""
+# disabled = false
+
+# [[commit_extra_fields]]
+# name = "scope"
+# prompt = "Select scope"
+# kind = "select"
+# required = false
+# prefetch.source = "command"
+# prefetch.command = "git log -50 --pretty=format:%s"
+# prefetch.extract_regex = "\\w+\\((?P<value>[^)]*)\\):"
+# prefetch.deduplicate = true
+
+# [[commit_extra_fields]]
+# name = "ticket"
+# prompt = "Ticket:"
+# kind = "text"
+# required = false
+# validation = "^[A-Z]+-[0-9]+$"
+# prefetch.source = "branch"
+# prefetch.extract_regex = "[A-Z]+-[0-9]+"
+
+##########
+# BRANCH #
+##########
+
+# Template applied to the generated branch name.
+# Built-in variables:
+#   {{branch_type}}   - the type chosen in the selector
+#   {{description}}   - the description entered by the user
+#   {{date}}          - YYYY-MM-DD
+#   {{time}}          - HH:MM:SS
+#   {{author}}        - git user.name
+# Conditional blocks: {{?var}}...{{/var}} renders only when var has a value.
+# Extra variables: add with [[branch_extra_fields]].
+# Commit extra fields (from [[commit_extra_fields]]) can also be referenced here.
+branch_template = "{{branch_type}}/{{description}}"
+
+# Dedicated branch types (when absent, commit_types is used).
+# branch_types = ["feat", "fix", "chore"]
+
+# When true, branch_types and commit_types are merged in the selector.
+# merge_branch_and_commit_types = false
+
+# Order of prompts for branch creation.
+# Use the reserved name "description" to position the built-in description prompt.
+# branch_field_order = ["description", "ticket"]
+
+# Overrides for the built-in description prompt (uncomment to customise or disable).
+# [branch_description]
+# prompt = "Branch description"
+# validation = ""
+# disabled = false
+
+# [[branch_extra_fields]]
+# name = "description"
+# prompt = "Small description in kebab-case"
+# kind = "text"
+# required = true
+# validation = "^[a-z][a-z0-9-]+$"
+"#
+    )
+}
+
 /// # Arguments
 /// * `scope` - Whether to create local (.rona.toml) or global (~/.config/rona.toml) config
 /// * `config` - Global configuration including verbose and dry-run settings
@@ -1134,10 +1316,7 @@ fn handle_config_command(scope: ConfigScope, exclude: bool, config: &Config) -> 
             std::fs::create_dir_all(parent)?;
         }
 
-        // Get default config and serialize to TOML
-        let default_config = crate::config::ProjectConfig::default();
-        let toml_content = toml::to_string_pretty(&default_config)
-            .map_err(|_| crate::errors::ConfigError::InvalidConfig)?;
+        let toml_content = generate_commented_config();
 
         // Write the config file
         let mut file = std::fs::File::create(&config_path)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,7 +87,7 @@ pub struct ProjectConfig {
     /// Extra fields not listed are appended after all listed items.
     /// When empty (the default), extra fields are shown first, then `message`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub field_order: Vec<String>,
+    pub commit_fields_order: Vec<String>,
 
     /// Template for branch name generation.
     /// Available variables: `{commit_type}`, `{description}`, `{date}`, `{time}`, `{author}`.
@@ -120,6 +120,14 @@ pub struct ProjectConfig {
     /// using `{extract}` as a placeholder. The result is offered as the default;
     /// pressing Enter without typing accepts it.
     pub message_prefetch: Option<crate::extra_fields::MessagePrefetchConfig>,
+
+    /// Optional overrides for the built-in commit message prompt.
+    /// Set `disabled = true` to skip the prompt (the `{message}` variable will be empty).
+    pub commit_message: Option<crate::extra_fields::BuiltInFieldConfig>,
+
+    /// Optional overrides for the built-in branch description prompt.
+    /// Set `disabled = true` to skip the prompt (the `{description}` variable will be empty).
+    pub branch_description: Option<crate::extra_fields::BuiltInFieldConfig>,
 }
 
 impl Default for ProjectConfig {
@@ -136,13 +144,15 @@ impl Default for ProjectConfig {
                 "{?commit_number}[{commit_number}] {/commit_number}({commit_type} on {branch_name}) {message}".to_string(),
             ),
             commit_extra_fields: vec![],
-            field_order: vec![],
+            commit_fields_order: vec![],
             branch_template: Some("{branch_type}/{description}".to_string()),
             branch_extra_fields: vec![],
             branch_field_order: vec![],
             branch_types: None,
             merge_branch_and_commit_types: false,
             message_prefetch: None,
+            commit_message: None,
+            branch_description: None,
         }
     }
 }
@@ -158,6 +168,9 @@ struct RawProjectConfig {
     template: Option<String>,
     commit_extra_fields: Option<Vec<crate::extra_fields::ExtraField>>,
     extra_fields: Option<Vec<crate::extra_fields::ExtraField>>,
+    /// Current name.
+    commit_fields_order: Option<Vec<String>>,
+    /// Legacy alias for `commit_fields_order`.
     field_order: Option<Vec<String>>,
     branch_template: Option<String>,
     branch_extra_fields: Option<Vec<crate::extra_fields::ExtraField>>,
@@ -165,6 +178,8 @@ struct RawProjectConfig {
     branch_types: Option<Vec<String>>,
     merge_branch_and_commit_types: Option<bool>,
     message_prefetch: Option<crate::extra_fields::MessagePrefetchConfig>,
+    commit_message: Option<crate::extra_fields::BuiltInFieldConfig>,
+    branch_description: Option<crate::extra_fields::BuiltInFieldConfig>,
 }
 
 impl From<RawProjectConfig> for ProjectConfig {
@@ -174,19 +189,22 @@ impl From<RawProjectConfig> for ProjectConfig {
             commit_types: raw.commit_types,
             commit_template: raw.commit_template,
             commit_extra_fields: raw.commit_extra_fields.unwrap_or_default(),
-            field_order: raw.field_order.unwrap_or_default(),
+            commit_fields_order: raw.commit_fields_order.unwrap_or_default(),
             branch_template: raw.branch_template,
             branch_extra_fields: raw.branch_extra_fields.unwrap_or_default(),
             branch_field_order: raw.branch_field_order.unwrap_or_default(),
             branch_types: raw.branch_types,
             merge_branch_and_commit_types: raw.merge_branch_and_commit_types.unwrap_or(false),
             message_prefetch: raw.message_prefetch,
+            commit_message: raw.commit_message,
+            branch_description: raw.branch_description,
         }
     }
 }
 
 /// Resolves backward-compat aliases within a single raw config.
-/// `template` → `commit_template` and `extra_fields` → `commit_extra_fields`.
+/// `template` → `commit_template`, `extra_fields` → `commit_extra_fields`,
+/// `field_order` → `commit_fields_order`.
 fn normalize_raw(mut raw: RawProjectConfig) -> RawProjectConfig {
     if raw.commit_template.is_none() {
         raw.commit_template = raw.template.take();
@@ -196,6 +214,10 @@ fn normalize_raw(mut raw: RawProjectConfig) -> RawProjectConfig {
         raw.commit_extra_fields = raw.extra_fields.take();
     }
     raw.extra_fields = None;
+    if raw.commit_fields_order.is_none() {
+        raw.commit_fields_order = raw.field_order.take();
+    }
+    raw.field_order = None;
     raw
 }
 
@@ -235,7 +257,8 @@ fn merge_raw(base: RawProjectConfig, child: RawProjectConfig) -> RawProjectConfi
             child.commit_extra_fields,
         ),
         extra_fields: None,
-        field_order: child.field_order.or(base.field_order),
+        commit_fields_order: child.commit_fields_order.or(base.commit_fields_order),
+        field_order: None,
         branch_template: child.branch_template.or(base.branch_template),
         branch_extra_fields: merge_named_fields(
             base.branch_extra_fields,
@@ -247,6 +270,8 @@ fn merge_raw(base: RawProjectConfig, child: RawProjectConfig) -> RawProjectConfi
             .merge_branch_and_commit_types
             .or(base.merge_branch_and_commit_types),
         message_prefetch: child.message_prefetch.or(base.message_prefetch),
+        commit_message: child.commit_message.or(base.commit_message),
+        branch_description: child.branch_description.or(base.branch_description),
     }
 }
 

--- a/src/extra_fields.rs
+++ b/src/extra_fields.rs
@@ -289,6 +289,21 @@ fn prompt_as_text(
     }
 }
 
+/// Configuration overrides for a built-in prompt field (e.g., the branch `description` or
+/// commit `message`).
+///
+/// All fields are optional; omitted fields fall back to the built-in defaults.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BuiltInFieldConfig {
+    /// Custom prompt text shown to the user.
+    pub prompt: Option<String>,
+    /// Optional regex the entered value must match.
+    pub validation: Option<String>,
+    /// When `true`, skip this prompt entirely (the template variable will be empty).
+    #[serde(default)]
+    pub disabled: bool,
+}
+
 /// Prefetch configuration specific to the built-in message prompt.
 ///
 /// Unlike `PrefetchConfig`, this supports a `template` that uses `{extract}` as a

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -208,11 +208,10 @@ pub fn format_branch_name(commit_types: &[&str], branch: &str) -> String {
 /// - Removes a trailing `/`
 #[must_use]
 pub fn sanitize_branch_name(name: &str) -> String {
-    let lowered: String = name
-        .to_lowercase()
+    let sanitized: String = name
         .chars()
         .map(|c| {
-            if matches!(c, 'a'..='z' | '0'..='9' | '/' | '_') {
+            if matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '/' | '_' | '-') {
                 c
             } else {
                 '-'
@@ -221,9 +220,9 @@ pub fn sanitize_branch_name(name: &str) -> String {
         .collect();
 
     // Collapse consecutive dashes and slashes
-    let mut result = String::with_capacity(lowered.len());
+    let mut result = String::with_capacity(sanitized.len());
     let mut prev = '\0';
-    for c in lowered.chars() {
+    for c in sanitized.chars() {
         if c == '-' && prev == '-' {
             continue;
         }


### PR DESCRIPTION
## Summary

- Add `BuiltInFieldConfig`: an optional config block that overrides the built-in `message` (commit) and `description` (branch) prompts. Supports custom prompt text, a regex validator, and a `disabled` flag to skip the prompt entirely (leaving the variable empty).
- Add `commit_message` and `branch_description` config keys in `.rona.toml` that accept a `BuiltInFieldConfig`.
- Rename `field_order` to `commit_fields_order` for clarity. The old key is kept as a legacy alias: if `commit_fields_order` is absent, the value of `field_order` is used, so existing configs keep working without changes.
- When generating a branch name, any `commit_extra_fields` whose names appear in the branch template are automatically pulled into the branch prompt if no `branch_extra_field` with the same name is already defined. Avoids duplicating field declarations.
- Branch name sanitization no longer lowercases the input and now treats `-` as a valid passthrough character, so casing entered by the user is preserved in the final branch name.

## BuiltInFieldConfig example

```toml
# .rona.toml

# Rename the commit message prompt and enforce a minimum-length pattern
[commit_message]
prompt = "Short description"
validation = "^.{10,}$"

# Skip the branch description prompt entirely
[branch_description]
disabled = true
```

Running `rona -g -i` with the above config:

```
> Select commit type       feat
> Short description        Add login endpoint
```

The `{message}` variable is populated with the validated value. With `branch_description.disabled = true`, running `rona branch` never asks for a description, and `{description}` resolves to an empty string.

## commit_extra_fields reuse in branch templates example

```toml
# .rona.toml
branch_template = "{branch_type}/{ticket}/{description}"

[[commit_extra_fields]]
name = "ticket"
kind = "text"
validation = "^[A-Z]+-[0-9]+$"
prefetch.source = "branch"
prefetch.extract_regex = "[A-Z]+-[0-9]+"
```

Running `rona branch` now prompts for `ticket` automatically without needing a separate `[[branch_extra_fields]]` block.
