### PR TITLE
[FEAT] Interactive file staging with `rona -a -i`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "rona"
-version = "2.23.2"
+version = "2.24.0"
 dependencies = [
  "arboard",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "Apache-2.0 OR MIT"
 name = "rona"
 readme = "README.md"
 repository = "https://github.com/rona-rs/rona"
-version = "2.23.2"
+version = "2.24.0"
 
 [[bin]]
 doc = true

--- a/README.md
+++ b/README.md
@@ -557,6 +557,9 @@ rona -a "target/" "node_modules/"
 
 # Exclude files with specific patterns
 rona -a "test_*.rs" "*.test.js"
+
+# Or pick files interactively from a checklist
+rona -a -i
 ```
 
 3. Generate and edit commit message:
@@ -789,6 +792,11 @@ rona add-with-exclude <pattern(s)>
 rona -a <pattern(s)>
 ```
 
+**Options:**
+
+- `-i, --interactive` - Pick files to stage from a checklist instead of using exclude patterns
+- `--dry-run` - Preview what would be staged without staging anything
+
 **Example:**
 
 ```bash
@@ -798,6 +806,16 @@ rona -a "*.rs" "*.tmp"  # Exclude Rust and temporary files
 cd packages/preview/my-pkg/1.0
 rona -a  # Correctly stages files relative to the repo root
 ```
+
+**Interactive mode (`-i`):**
+
+Instead of describing what to leave out with exclude patterns, pick exactly what to stage from a checklist of changed files (similar to `git add -p` or the lazygit file selector). Use the arrow keys to move, space to toggle a file, and enter to confirm. Untracked, modified, type-changed and deleted files are all listed with a short status label.
+
+```bash
+rona -a -i  # Open a MultiSelect of changed files and stage the selected ones
+```
+
+When `-i` is used, any exclude patterns are ignored.
 
 ### `commit` (`-c`)
 

--- a/completions/rona.bash
+++ b/completions/rona.bash
@@ -166,7 +166,7 @@ _rona() {
             return 0
             ;;
         rona__subcmd__add__subcmd__with__subcmd__exclude)
-            opts="-f -h --dry-run --config-file --help [PATTERNS]..."
+            opts="-i -f -h --interactive --dry-run --config-file --help [PATTERNS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/rona.elv
+++ b/completions/rona.elv
@@ -50,6 +50,8 @@ set edit:completion:arg-completer[rona] = {|@words|
         &'rona;add-with-exclude'= {
             cand -f 'Config file to use instead of the default global/project hierarchy'
             cand --config-file 'Config file to use instead of the default global/project hierarchy'
+            cand -i 'Interactively pick which changed files to stage (`MultiSelect` of git status)'
+            cand --interactive 'Interactively pick which changed files to stage (`MultiSelect` of git status)'
             cand --dry-run 'Show what would be added without actually adding files'
             cand -h 'Print help'
             cand --help 'Print help'

--- a/completions/rona.fish
+++ b/completions/rona.fish
@@ -45,6 +45,7 @@ complete -c rona -n "__fish_rona_using_subcommand branch" -l dry-run -d 'Show wh
 complete -c rona -n "__fish_rona_using_subcommand branch" -l no-switch -d 'Create the branch without switching to it'
 complete -c rona -n "__fish_rona_using_subcommand branch" -s h -l help -d 'Print help'
 complete -c rona -n "__fish_rona_using_subcommand add-with-exclude" -s f -l config-file -d 'Config file to use instead of the default global/project hierarchy' -r -F
+complete -c rona -n "__fish_rona_using_subcommand add-with-exclude" -s i -l interactive -d 'Interactively pick which changed files to stage (`MultiSelect` of git status)'
 complete -c rona -n "__fish_rona_using_subcommand add-with-exclude" -l dry-run -d 'Show what would be added without actually adding files'
 complete -c rona -n "__fish_rona_using_subcommand add-with-exclude" -s h -l help -d 'Print help'
 complete -c rona -n "__fish_rona_using_subcommand commit" -s f -l config-file -d 'Config file to use instead of the default global/project hierarchy' -r -F

--- a/completions/rona.ps1
+++ b/completions/rona.ps1
@@ -55,6 +55,8 @@ Register-ArgumentCompleter -Native -CommandName 'rona' -ScriptBlock {
         'rona;add-with-exclude' {
             [CompletionResult]::new('-f', '-f', [CompletionResultType]::ParameterName, 'Config file to use instead of the default global/project hierarchy')
             [CompletionResult]::new('--config-file', '--config-file', [CompletionResultType]::ParameterName, 'Config file to use instead of the default global/project hierarchy')
+            [CompletionResult]::new('-i', '-i', [CompletionResultType]::ParameterName, 'Interactively pick which changed files to stage (`MultiSelect` of git status)')
+            [CompletionResult]::new('--interactive', '--interactive', [CompletionResultType]::ParameterName, 'Interactively pick which changed files to stage (`MultiSelect` of git status)')
             [CompletionResult]::new('--dry-run', '--dry-run', [CompletionResultType]::ParameterName, 'Show what would be added without actually adding files')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')

--- a/completions/rona.zsh
+++ b/completions/rona.zsh
@@ -46,6 +46,8 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '-f+[Config file to use instead of the default global/project hierarchy]:PATH:_files' \
 '--config-file=[Config file to use instead of the default global/project hierarchy]:PATH:_files' \
+'-i[Interactively pick which changed files to stage (\`MultiSelect\` of git status)]' \
+'--interactive[Interactively pick which changed files to stage (\`MultiSelect\` of git status)]' \
 '--dry-run[Show what would be added without actually adding files]' \
 '-h[Print help]' \
 '--help[Print help]' \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,7 +31,7 @@ use clap_complete::{Shell, generate};
 use colored::Colorize;
 use glob::Pattern;
 use inquire::ui::{Attributes, Color, RenderConfig, StyleSheet, Styled};
-use inquire::{Confirm, Select, Text};
+use inquire::{Confirm, MultiSelect, Select, Text};
 use std::{collections::HashMap, fs::read_to_string, io, process::Command};
 
 use crate::{
@@ -44,8 +44,9 @@ use crate::{
     git::{
         COMMIT_MESSAGE_FILE_PATH, COMMIT_TYPES, add_to_git_exclude, create_needed_files,
         format_branch_name, generate_commit_message, get_current_branch, get_current_commit_nb,
-        get_status_files, get_top_level_path, git_add_with_exclude_patterns, git_branch_only,
-        git_commit, git_create_branch, git_push, sanitize_branch_name,
+        get_stageable_files, get_status_files, get_top_level_path, git_add_files,
+        git_add_with_exclude_patterns, git_branch_only, git_commit, git_create_branch, git_push,
+        sanitize_branch_name,
     },
     template::{
         BranchTemplateVariables, TemplateVariables, process_branch_template, process_template,
@@ -115,6 +116,10 @@ pub(crate) enum CliCommand {
         /// Patterns of files to exclude (supports glob patterns like `"node_modules/*"`)
         #[arg(value_name = "PATTERNS", value_hint = ValueHint::AnyPath)]
         to_exclude: Vec<String>,
+
+        /// Interactively pick which changed files to stage (`MultiSelect` of git status)
+        #[arg(short = 'i', long = "interactive", default_value_t = false)]
+        interactive: bool,
 
         /// Show what would be added without actually adding files
         #[arg(long, default_value_t = false)]
@@ -561,7 +566,11 @@ fn handle_branch(no_switch: bool, config: &Config) -> Result<()> {
 /// * If any glob pattern is invalid
 /// * If git add operation fails
 /// * If reading git status fails
-fn handle_add_with_exclude(exclude: &[String], config: &Config) -> Result<()> {
+fn handle_add_with_exclude(exclude: &[String], interactive: bool, config: &Config) -> Result<()> {
+    if interactive {
+        return handle_add_interactive(exclude, config);
+    }
+
     let patterns: Vec<Pattern> = exclude
         .iter()
         .map(|p| {
@@ -571,6 +580,42 @@ fn handle_add_with_exclude(exclude: &[String], config: &Config) -> Result<()> {
         .collect::<Result<Vec<Pattern>>>()?;
 
     git_add_with_exclude_patterns(&patterns, config.verbose, config.dry_run)?;
+    Ok(())
+}
+
+/// Handle the interactive variant of the add command (`rona -a -i`).
+///
+/// Presents a `MultiSelect` of every file with unstaged changes and stages only
+/// the ones the user selects. Exclude patterns are not used in this mode.
+///
+/// # Arguments
+/// * `exclude` - Patterns passed on the command line (ignored, only used to warn)
+/// * `config` - Global configuration including dry-run settings
+///
+/// # Errors
+/// * If reading git status fails
+/// * If the user cancels the prompt
+/// * If staging the selected files fails
+fn handle_add_interactive(exclude: &[String], config: &Config) -> Result<()> {
+    if !exclude.is_empty() {
+        println!(
+            "{} Exclude patterns are ignored in interactive mode (-i).",
+            "WARNING:".yellow().bold()
+        );
+    }
+
+    let entries = get_stageable_files()?;
+    if entries.is_empty() {
+        println!("No changes to stage.");
+        return Ok(());
+    }
+
+    let selected = MultiSelect::new("Select files to stage", entries)
+        .prompt()
+        .map_err(|_| RonaError::UserCancelled)?;
+
+    let paths: Vec<String> = selected.into_iter().map(|entry| entry.path).collect();
+    git_add_files(&paths, config.dry_run)?;
     Ok(())
 }
 
@@ -1385,10 +1430,11 @@ pub fn run() -> Result<()> {
 
         CliCommand::AddWithExclude {
             to_exclude: exclude,
+            interactive,
             dry_run,
         } => {
             config.set_dry_run(dry_run);
-            handle_add_with_exclude(&exclude, &config)
+            handle_add_with_exclude(&exclude, interactive, &config)
         }
 
         CliCommand::Commit {
@@ -1477,12 +1523,14 @@ mod cli_tests {
 
         let CliCommand::AddWithExclude {
             to_exclude: exclude,
+            interactive,
             dry_run,
         } = cli.command
         else {
             return Err("Wrong command parsed".into());
         };
         assert!(exclude.is_empty());
+        assert!(!interactive);
         assert!(!dry_run);
         Ok(())
     }
@@ -1494,12 +1542,14 @@ mod cli_tests {
 
         let CliCommand::AddWithExclude {
             to_exclude: exclude,
+            interactive,
             dry_run,
         } = cli.command
         else {
             return Err("Wrong command parsed".into());
         };
         assert_eq!(exclude, vec!["*.txt"]);
+        assert!(!interactive);
         assert!(!dry_run);
         Ok(())
     }
@@ -1511,12 +1561,14 @@ mod cli_tests {
 
         let CliCommand::AddWithExclude {
             to_exclude: exclude,
+            interactive,
             dry_run,
         } = cli.command
         else {
             return Err("Wrong command parsed".into());
         };
         assert_eq!(exclude, vec!["*.txt", "*.log", "target/*"]);
+        assert!(!interactive);
         assert!(!dry_run);
         Ok(())
     }
@@ -1528,13 +1580,46 @@ mod cli_tests {
 
         let CliCommand::AddWithExclude {
             to_exclude: exclude,
+            interactive,
             dry_run,
         } = cli.command
         else {
             return Err("Wrong command parsed".into());
         };
         assert_eq!(exclude, vec!["*.txt"]);
+        assert!(!interactive);
         assert!(!dry_run);
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_interactive() -> TestResult {
+        let args = vec!["rona", "-a", "-i"];
+        let cli = Cli::try_parse_from(args)?;
+
+        let CliCommand::AddWithExclude {
+            to_exclude: exclude,
+            interactive,
+            dry_run,
+        } = cli.command
+        else {
+            return Err("Wrong command parsed".into());
+        };
+        assert!(exclude.is_empty());
+        assert!(interactive);
+        assert!(!dry_run);
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_interactive_long_flag() -> TestResult {
+        let args = vec!["rona", "-a", "--interactive"];
+        let cli = Cli::try_parse_from(args)?;
+
+        let CliCommand::AddWithExclude { interactive, .. } = cli.command else {
+            return Err("Wrong command parsed".into());
+        };
+        assert!(interactive);
         Ok(())
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -284,8 +284,8 @@ fn get_render_config() -> RenderConfig<'static> {
     render_config.prompt_prefix = Styled::new("$").with_fg(Color::LightRed);
     render_config.answered_prompt_prefix = Styled::new("✔").with_fg(Color::LightGreen);
     render_config.highlighted_option_prefix = Styled::new("➠").with_fg(Color::LightBlue);
-    render_config.selected_checkbox = Styled::new("☑").with_fg(Color::LightGreen);
-    render_config.unselected_checkbox = Styled::new("☐").with_fg(Color::Black);
+    render_config.selected_checkbox = Styled::new("[x]").with_fg(Color::LightGreen);
+    render_config.unselected_checkbox = Styled::new("[ ]").with_fg(Color::Black);
     render_config.scroll_up_prefix = Styled::new("⇞").with_fg(Color::Black);
     render_config.scroll_down_prefix = Styled::new("⇟").with_fg(Color::Black);
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -46,8 +46,8 @@ pub use commit::{
 pub use files::{add_to_git_exclude, create_needed_files};
 pub use remote::git_push;
 pub use repository::{find_git_root, get_top_level_path};
-pub use staging::git_add_with_exclude_patterns;
-pub use status::{get_all_staged_file_paths, get_status_files};
+pub use staging::{git_add_files, git_add_with_exclude_patterns};
+pub use status::{StatusEntry, get_all_staged_file_paths, get_stageable_files, get_status_files};
 
 /// Handles the output of `Command`-based git operations (push, pull, merge, rebase).
 ///

--- a/src/git/staging.rs
+++ b/src/git/staging.rs
@@ -299,6 +299,53 @@ pub fn git_add_with_exclude_patterns(
     Ok(())
 }
 
+/// Stages an explicit list of files via `git add -- <files>`.
+///
+/// Used by the interactive add mode (`rona -a -i`) after the user has selected
+/// which files to stage. Deletions are staged correctly because `git add`
+/// records the removal of a tracked file that no longer exists.
+///
+/// # Arguments
+/// * `files` - Paths (relative to the repository root) to stage
+/// * `dry_run` - If true, only print what would be staged without staging anything
+///
+/// # Errors
+/// * If locating the repository root fails
+/// * If the `git add` command fails
+pub fn git_add_files(files: &[String], dry_run: bool) -> Result<()> {
+    if files.is_empty() {
+        println!("No files selected.");
+        return Ok(());
+    }
+
+    if dry_run {
+        println!("Would stage {} files:", files.len());
+        for file in files {
+            println!("  + {file}");
+        }
+        return Ok(());
+    }
+
+    let repo_root = get_top_level_path()?;
+    let output = Command::new("git")
+        .current_dir(&repo_root)
+        .args(["add", "--"])
+        .args(files)
+        .output()
+        .map_err(RonaError::Io)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(RonaError::Git(GitError::CommandFailed {
+            command: "git add --".to_string(),
+            output: stderr.trim().to_string(),
+        }));
+    }
+
+    println!("Staged {} files for commit.", files.len());
+    Ok(())
+}
+
 /// Prints a detailed summary of files that would be affected by a git add operation in dry run mode.
 ///
 /// This function provides a clear overview of:

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -170,6 +170,77 @@ pub fn get_status_files() -> Result<Vec<String>> {
     Ok(files.into_iter().collect())
 }
 
+/// A single entry from `git status` that has unstaged changes and can be staged.
+///
+/// Used by the interactive add mode (`rona -a -i`) to present a `MultiSelect` of
+/// changed files. The [`Display`] implementation renders a human-readable status
+/// label followed by the path, e.g. `modified    src/main.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusEntry {
+    /// Path to the file, relative to the repository root.
+    pub path: String,
+    /// Short, human-readable status label (e.g. "modified", "untracked").
+    pub status: &'static str,
+}
+
+impl std::fmt::Display for StatusEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:<11} {}", self.status, self.path)
+    }
+}
+
+/// Returns the files that currently have unstaged changes and can be staged.
+///
+/// This includes untracked files and files with working-tree modifications,
+/// deletions or type changes. Fully staged files with no remaining working-tree
+/// changes are omitted, since there is nothing left to stage for them.
+///
+/// The list is sorted by path for stable, predictable ordering in the selector.
+///
+/// # Errors
+/// * If reading git status fails
+///
+/// # Returns
+/// * `Vec<StatusEntry>` - The stageable files with their status labels
+pub fn get_stageable_files() -> Result<Vec<StatusEntry>> {
+    let lines = run_git_status()?;
+    let mut entries = Vec::new();
+
+    for line in &lines {
+        if line.len() < 4 {
+            continue;
+        }
+
+        let mut chars = line.chars();
+        let index_char = chars.next().unwrap_or(' ');
+        let wt_char = chars.next().unwrap_or(' ');
+
+        let is_untracked = index_char == '?' && wt_char == '?';
+
+        // Skip files whose working tree matches the index (nothing left to stage).
+        if wt_char == ' ' && !is_untracked {
+            continue;
+        }
+
+        // For renamed-and-modified entries the path is "old -> new"; stage the new path.
+        let raw_path = &line[3..];
+        let path_part = raw_path.rsplit(" -> ").next().unwrap_or(raw_path);
+        let path = unquote_git_path(path_part);
+
+        let status = match wt_char {
+            'D' => "deleted",
+            'T' => "type change",
+            '?' => "untracked",
+            _ => "modified",
+        };
+
+        entries.push(StatusEntry { path, status });
+    }
+
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(entries)
+}
+
 /// Processes deleted files that need to be staged for deletion.
 /// Only returns files that are deleted in the working directory but not yet staged.
 ///


### PR DESCRIPTION
## Summary

- Adds `-i`/`--interactive` to `add-with-exclude` (`rona -a`): instead of describing what to leave out with exclude patterns, pick exactly what to stage from a `MultiSelect` checklist of changed files (similar to `git add -p` or the lazygit file selector). This is the additive opposite of the existing exclusion-based flow.
- New `get_stageable_files()` in `git/status.rs` lists every file with unstaged working-tree changes (untracked, modified, type-changed, deleted), resolves `old -> new` rename paths to the new path, and sorts by path for stable ordering.
- New `StatusEntry` struct carries the path plus a short, human-readable status label and renders as `modified    src/main.rs` in the selector via its `Display` impl.
- New `git_add_files(files, dry_run)` in `git/staging.rs` stages an explicit list via `git add -- <files>`. Deletions are staged correctly because `git add` records the removal of a tracked file that no longer exists.
- Exclude patterns are ignored in interactive mode; passing both prints a warning. `--dry-run` lists what would be staged after selection without touching the index.
- Regenerated shell completions for all five shells so the new flag completes. The fish custom `__rona_status_files` block is preserved.

## Example

```bash
# Open a MultiSelect of changed files and stage only the selected ones
rona -a -i
```

```
> Select files to stage
  [x] modified    src/cli.rs
  [ ] untracked   notes.txt
  [x] deleted     old_module.rs
  [ ] modified    README.md
Staged 2 files for commit.
```

Use the arrow keys to move, space to toggle a file, and enter to confirm. The non-interactive pattern-exclusion behavior of `rona -a` is unchanged.